### PR TITLE
Add author and time to article

### DIFF
--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -5,8 +5,9 @@
 <ul>
   <% @articles.each do |article| %>
     <li>
-      <%= article.title %><br />
-      <%= article.content %><br/>
+      <p><%= article.title %></p>
+      <p><%= article.content %></p>
+      <p>Written by <%= article.author %> at <%= Date.strptime("#{Article.first.created_at}", '%Y-%m-%d') %></p>
       <%= link_to 'Edit Article', edit_article_path(article) %><br/>
       <%= link_to 'Show', article_path(article)%>
     </li>

--- a/db/migrate/20180112151449_add_author_to_articles.rb
+++ b/db/migrate/20180112151449_add_author_to_articles.rb
@@ -1,0 +1,5 @@
+class AddAuthorToArticles < ActiveRecord::Migration[5.1]
+  def change
+    add_column :articles, :author, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171201215540) do
+ActiveRecord::Schema.define(version: 20180112151449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20171201215540) do
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "author"
   end
 
   create_table "comments", force: :cascade do |t|

--- a/features/list_articles.feature
+++ b/features/list_articles.feature
@@ -5,13 +5,15 @@ Feature: List articles on landing page
 
   Background:
   Given the following articles exists
-    | title                | content                            |
-    | A breaking news item | Some really breaking action        |
-    | Learn Rails 5        | Build awesome rails applications   |
+    | title                | content                            | author |
+    | A breaking news item | Some really breaking action        | thomas |
+    | Learn Rails 5        | Build awesome rails applications   | faraz  |
 
   Scenario: Viewing list of articles on application's landing page
     When I am on the landing page
     Then I should see "A breaking news item"
     And I should see "Some really breaking action"
+    And I should see "Written by thomas at 2018-01-12"
     And I should see "Learn Rails 5"
     And I should see "Build awesome rails applications"
+    And I should see "by faraz at 2018-01-12"

--- a/features/step_definitions/landing_page_steps.rb
+++ b/features/step_definitions/landing_page_steps.rb
@@ -40,3 +40,7 @@ end
 When("I fill in {string} as {string}") do |reader, email|
   fill_in reader, with: email
 end
+
+Then("show me the page") do
+  save_and_open_page
+end


### PR DESCRIPTION
As a visitor
In order to see the author and date of the article
I would like to be able to see the author and date of the article when I see the list of articles

Note that `features/list_articles.feature` won't pass from tomorrow because the feature file is written in a way that accepts only articles created with 2018-01-12 as date